### PR TITLE
feat: add system-wide venv support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ ifndef GROUPMETDIR
 $(error GROUPMETDIR must be specified. Example: make install GROUPMETDIR="/your/group/metadata/path")
 endif
 
+ifndef SYSTEMENVDIR
+$(error SYSTEMENVDIR must be specified. Example: make install SYSTEMENVDIR="/sw/hprc/sw/modulair/hprc_envs")
+endif
+
+ifndef SYSTEMADMINGROUP
+$(error SYSTEMADMINGROUP must be specified. Example: make install SYSTEMADMINGROUP="hprc")
+endif
+
 # Template and output files
 TEMPLATES := activate_venv.template list_venvs.template create_venv.template delete_venv.template add_venv.template utils.py.template json_to_command.template
 SCRIPTS := activate_venv list_venvs create_venv delete_venv utils.py json_to_command add_venv
@@ -32,6 +40,7 @@ build: directories $(SCRIPTS)
 	@echo "Log directory: $(LOGDIR)"
 	@echo "User metadata location: $(METDIR)"
 	@echo "Group metadata location: $(GROUPMETDIR)"
+	@echo "System env location: $(SYSTEMENVDIR)"
 
 # Create necessary directories
 .PHONY: directories
@@ -110,6 +119,8 @@ utils.py: $(SRCDIR)/utils.py.template
 	@cp $< $@
 	@sed -i 's|<METDIR>|$(METDIR)|g' $@
 	@sed -i 's|<GROUPMETDIR>|$(GROUPMETDIR)|g' $@
+	@sed -i 's|<SYSTEMENVDIR>|$(SYSTEMENVDIR)|g' $@
+	@sed -i 's|<SYSTEMADMINGROUP>|$(SYSTEMADMINGROUP)|g' $@
 
 # Install target - copies processed scripts to bin directory
 .PHONY: install
@@ -178,18 +189,20 @@ help:
 	@echo "  help        - Show this help message"
 	@echo ""
 	@echo "Configuration variables (REQUIRED):"
-	@echo "  METDIR      - User metadata directory location (REQUIRED)"
-	@echo "  GROUPMETDIR - Group metadata directory location (REQUIRED)"
+	@echo "  METDIR       - User metadata directory location (REQUIRED)"
+	@echo "  GROUPMETDIR  - Group metadata directory location (REQUIRED)"
+	@echo "  SYSTEMENVDIR      - System-wide hprc_envs directory location (REQUIRED)"
+	@echo "  SYSTEMADMINGROUP  - Group with permission to manage system envs (REQUIRED)"
 	@echo ""
 	@echo "Examples for different HPC environments:"
 	@echo "  # SCRATCH-based systems:"
-	@echo "  make install METDIR=/scratch/user/\$$USER GROUPMETDIR=/scratch/group"
+	@echo "  make install METDIR=/scratch/user/\$$USER GROUPMETDIR=/scratch/group SYSTEMENVDIR=/sw/hprc/sw/modulair/hprc_envs SYSTEMADMINGROUP=hprc"
 	@echo ""
 	@echo "  # Home directory systems:"
-	@echo "  make install METDIR=/home/\$$USER/.venvs GROUPMETDIR=/shared/groups"
+	@echo "  make install METDIR=/home/\$$USER/.venvs GROUPMETDIR=/shared/groups SYSTEMENVDIR=/sw/hprc/sw/modulair/hprc_envs SYSTEMADMINGROUP=hprc"
 	@echo ""
 	@echo "  # Development/testing:"
-	@echo "  make dev METDIR=/tmp/\$$USER/test GROUPMETDIR=/tmp/groups"
+	@echo "  make dev METDIR=/tmp/\$$USER/test GROUPMETDIR=/tmp/groups SYSTEMENVDIR=/tmp/hprc_envs SYSTEMADMINGROUP=testadmins"
 
 # Declare all targets as phony to avoid conflicts with files of the same name
 .PHONY: all build install dev clean clean-all help directories

--- a/setup.sh
+++ b/setup.sh
@@ -26,8 +26,22 @@ if [ -z "$MODULAIR_GROUP_METADATA_DIR" ]; then
     exit 1
 fi
 
+if [ -z "$MODULAIR_SYSTEM_ENV_DIR" ]; then
+    echo "Error: MODULAIR_SYSTEM_ENV_DIR environment variable must be set."
+    echo "Example: MODULAIR_SYSTEM_ENV_DIR=\"/sw/hprc/sw/modulair/hprc_envs\" ./setup.sh"
+    exit 1
+fi
+
+if [ -z "$MODULAIR_SYSTEM_ADMIN_GROUP" ]; then
+    echo "Error: MODULAIR_SYSTEM_ADMIN_GROUP environment variable must be set."
+    echo "Example: MODULAIR_SYSTEM_ADMIN_GROUP=\"hprc\" ./setup.sh"
+    exit 1
+fi
+
 metadataloc="$MODULAIR_METADATA_DIR"
 groupmetaloc="$MODULAIR_GROUP_METADATA_DIR"
+systemenvdir="$MODULAIR_SYSTEM_ENV_DIR"
+systemadmingroup="$MODULAIR_SYSTEM_ADMIN_GROUP"
 
 echo "Setting up ModuLair with the following configuration:"
 echo "  Root directory: $rootdir"
@@ -35,6 +49,8 @@ echo "  Binary directory: $default_bindir"
 echo "  Log directory: $default_logdir"
 echo "  User metadata location: $metadataloc"
 echo "  Group metadata location: $groupmetaloc"
+echo "  System env location: $systemenvdir"
+echo "  System admin group: $systemadmingroup"
 echo
 
 # Create necessary directories
@@ -50,6 +66,8 @@ if [ -f "src/modulair_cli.template" ]; then
     sed -i "s|<LOGDIR>|${default_logdir}|g" modulair_cli.py
     sed -i "s|<METDIR>|${metadataloc}|g" modulair_cli.py
     sed -i "s|<GROUPMETDIR>|${groupmetaloc}|g" modulair_cli.py
+    sed -i "s|<SYSTEMENVDIR>|${systemenvdir}|g" modulair_cli.py
+    sed -i "s|<SYSTEMADMINGROUP>|${systemadmingroup}|g" modulair_cli.py
     chmod +x modulair_cli.py
 else
     echo "Error: modulair_cli.template not found in src/"
@@ -84,10 +102,14 @@ if [ -f "src/utils.py.template" ]; then
     cp src/utils.py.template utils.py
     sed -i "s|<METDIR>|${metadataloc}|g" utils.py
     sed -i "s|<GROUPMETDIR>|${groupmetaloc}|g" utils.py
+    sed -i "s|<SYSTEMENVDIR>|${systemenvdir}|g" utils.py
+    sed -i "s|<SYSTEMADMINGROUP>|${systemadmingroup}|g" utils.py
 elif [ -f "src/utils.py" ]; then
     cp src/utils.py utils.py
     sed -i "s|<METDIR>|${metadataloc}|g" utils.py
     sed -i "s|<GROUPMETDIR>|${groupmetaloc}|g" utils.py
+    sed -i "s|<SYSTEMENVDIR>|${systemenvdir}|g" utils.py
+    sed -i "s|<SYSTEMADMINGROUP>|${systemadmingroup}|g" utils.py
 else
     echo "Error: Neither utils.py.template nor utils.py found in src/"
     exit 1
@@ -202,6 +224,8 @@ echo
 echo "Configuration used:"
 echo "  User metadata location: $metadataloc"
 echo "  Group metadata location: $groupmetaloc"
+echo "  System env location: $systemenvdir"
+echo "  System admin group: $systemadmingroup"
 echo "  Binary directory: $default_bindir"
 echo "  Log directory: $default_logdir"
 echo ""

--- a/src/modulair_cli.template
+++ b/src/modulair_cli.template
@@ -14,9 +14,11 @@ from utils import (
     get_user,
     get_user_metaloc,
     get_group_metaloc,
+    get_system_metaloc,
     get_user_groups,
     load_user_metadata,
     load_group_metadata,
+    load_system_metadata,
     load_all_metadata,
     find_environment_by_name,
     get_environment_path,
@@ -28,7 +30,8 @@ from utils import (
     check_group,
     get_terminal_width,
     truncate_text,
-    wrap_text
+    wrap_text,
+    SYSTEM_ADMIN_GROUP
 )
 
 def cmd_create(args):
@@ -43,8 +46,13 @@ def cmd_create(args):
     venv_name = args.name
     description = args.description
     group = args.group
+    system_flag = args.system
     toolchain = args.toolchain
     user_python_version = args.python
+
+    if system_flag and group != "":
+        print("Error: --system and --group are mutually exclusive.")
+        sys.exit(1)
 
     if(user_python_version == "-1" and toolchain == ""):
         eb_root_python = os.environ.get('EBROOTPYTHON')
@@ -91,7 +99,15 @@ def cmd_create(args):
         print("Error: Invalid virtual environment name. It must not contain spaces or special characters.")
         sys.exit(1)
 
-    if group != "":
+    if system_flag:
+        if not check_group(SYSTEM_ADMIN_GROUP):
+            print("Error: You do not have permission to perform this action.")
+            sys.exit(1)
+        system_metaloc = get_system_metaloc()
+        venv_path = os.path.join(system_metaloc, venv_name)
+        metadata_file = os.path.join(system_metaloc, 'metadata.json')
+        log_file = os.path.join(system_metaloc, 'creation.log')
+    elif group != "":
         if check_group(group):
             group_metaloc = get_group_metaloc()
             venv_path = os.path.join(group_metaloc, group, 'virtual_envs', venv_name)
@@ -123,7 +139,12 @@ def cmd_create(args):
         print("Error: venv already exists")
         sys.exit(1)
 
-    print(f"Creating virtual environment '{venv_name}' in your metadata directory. This may take a minute.")
+    if system_flag:
+        print(f"Creating virtual environment '{venv_name}' in the system directory. This may take a minute.")
+    elif group != "":
+        print(f"Creating virtual environment '{venv_name}' in group '{group}' directory. This may take a minute.")
+    else:
+        print(f"Creating virtual environment '{venv_name}' in your metadata directory. This may take a minute.")
     creation_command = ""
     if (user_python_version == "-1" and toolchain == ""):
         creation_command = f"python3 -m venv --system-site-packages {venv_path}"
@@ -161,7 +182,7 @@ def cmd_create(args):
     else:
         metadata = {"environments": []}
 
-    metadata["environments"].append({
+    env_entry = {
         "name": venv_name,
         "python_version": python_version,
         "GCCcore_version": gcccore_version,
@@ -169,7 +190,10 @@ def cmd_create(args):
         "toolchain": toolchain,
         "group": group,
         "owner": get_user()
-    })
+    }
+    if system_flag:
+        env_entry["system"] = True
+    metadata["environments"].append(env_entry)
 
     with open(metadata_file, 'w') as f:
         json.dump(metadata, f, indent=4)
@@ -284,6 +308,19 @@ def print_environments_table(metadata, group_name="your $SCRATCH"):
                 print(line.rstrip())
 
 def cmd_list(args):
+    if args.system:
+        try:
+            metadata = load_system_metadata()
+            if args.names_only:
+                for env in metadata.get('environments', []):
+                    print(env.get('name', 'N/A'))
+            else:
+                print(json.dumps(metadata, indent=4))
+        except Exception as e:
+            print(f"Error loading system metadata: {e}")
+            sys.exit(1)
+        return
+
     if args.user:
         try:
             metadata = load_user_metadata()
@@ -319,7 +356,8 @@ def cmd_list(args):
                 group_envs = []
                 for group_metadata in all_metadata['groups'].values():
                     group_envs.extend(group_metadata.get('environments', []))
-                all_envs = user_envs + group_envs
+                system_envs = all_metadata['system'].get('environments', [])
+                all_envs = system_envs + user_envs + group_envs
                 for env in all_envs:
                     print(env.get('name', 'N/A'))
             else:
@@ -334,6 +372,10 @@ def cmd_list(args):
 
         user_envs = all_metadata['user'].get('environments', [])
         groups = all_metadata.get('groups', {})
+        system_metadata = all_metadata.get('system', {"environments": []})
+
+        if system_metadata.get('environments'):
+            print_environments_table(system_metadata, "system (hprc_envs)")
 
         for group_name, group_metadata in groups.items():
             print_environments_table(group_metadata, f"group '{group_name}'")
@@ -341,7 +383,9 @@ def cmd_list(args):
         print_environments_table(all_metadata['user'], "your $SCRATCH")
 
         example_env = None
-        if user_envs:
+        if system_metadata.get('environments'):
+            example_env = system_metadata['environments'][0].get('name')
+        elif user_envs:
             example_env = user_envs[0].get('name')
         else:
             for group_metadata in groups.values():
@@ -400,11 +444,23 @@ def cmd_activate(args):
     
     if eval_mode:
         print(full_command)
+        if source_type == 'system':
+            print(f"echo ''")
+            print(f"echo 'Note: This is a system-managed environment. It is read-only — you will not be able to install,'")
+            print(f"echo 'remove, or modify packages (e.g. pip install will fail). If you need a customizable'")
+            print(f"echo 'environment, create your own with: modulair create <name>'")
+            print(f"echo ''")
     else:
         print(f"To activate '{env_name}', run:")
         print(f"  source modulair activate {env_name}")
         print(f"If you loaded ModuLair module, to activate '{env_name}', run without source command:")
         print(f"  modulair activate {env_name}")
+        if source_type == 'system':
+            print()
+            print(f"Note: This is a system-managed environment. It is read-only — you will not be able to install,")
+            print(f"remove, or modify packages (e.g. pip install will fail). If you need a customizable")
+            print(f"environment, create your own with: modulair create <name>")
+            print()
 
     logfilePath = os.path.join('<LOGDIR>/venv.log')
     try:
@@ -433,7 +489,15 @@ def cmd_delete(args):
         print(f"Error determining environment path: {e}")
         sys.exit(1)
 
-    location_desc = f"your $SCRATCH" if source_type == 'user' else f"group '{source_name}'"
+    if source_type == 'system':
+        if not check_group(SYSTEM_ADMIN_GROUP):
+            print("Error: You do not have permission to perform this action.")
+            sys.exit(1)
+        location_desc = "system (hprc_envs)"
+    elif source_type == 'user':
+        location_desc = "your $SCRATCH"
+    else:
+        location_desc = f"group '{source_name}'"
     print(f"Found environment '{env_name}' in {location_desc}")
 
     print(f"\nEnvironment details:")
@@ -508,18 +572,23 @@ def main():
     
     subparsers = parser.add_subparsers(dest='command', help='Available commands')
     
+    _is_admin = check_group(SYSTEM_ADMIN_GROUP)
+    _system_help = argparse.SUPPRESS if not _is_admin else None
+
     create_parser = subparsers.add_parser('create', help='Create a new virtual environment')
     create_parser.add_argument('name', help='Name of the virtual environment (no spaces or special characters)')
     create_parser.add_argument('-d', '--description', help='Optional description of the environment', default='')
     create_parser.add_argument('-g', '--group', help='Optional name of the group for shared environment', default='')
+    create_parser.add_argument('--system', action='store_true', help=_system_help or 'Create environment in system-wide location')
     create_parser.add_argument('-t', '--toolchain', help='Space-separated list of modules to load during creation', default='')
     create_parser.add_argument('-p', '--python', help='Specify the Python version', default='-1')
     create_parser.set_defaults(func=cmd_create)
-    
+
     list_parser = subparsers.add_parser('list', help='List virtual environments')
     list_parser.add_argument('-u', '--user', action='store_true', help="List user's $SCRATCH environments in JSON format")
     list_parser.add_argument('-g', '--groups', action='store_true', help="List user's group environments in JSON format (all groups)")
-    list_parser.add_argument('-a', '--all', action='store_true', help="List all user's environments in JSON format (user + groups)")
+    list_parser.add_argument('-a', '--all', action='store_true', help="List all environments in JSON format (system + user + groups)")
+    list_parser.add_argument('--system', action='store_true', help=_system_help or 'List only system-wide environments')
     list_parser.add_argument('-n', '--names-only', action='store_true', help='List environment names only')
     list_parser.add_argument('--no-log', action='store_true', help='Disable logging for this run')
     list_parser.set_defaults(func=cmd_list)

--- a/src/utils.py.template
+++ b/src/utils.py.template
@@ -13,6 +13,10 @@ import subprocess
 import textwrap
 
 
+SYSTEM_ENV_DIR = "<SYSTEMENVDIR>"
+SYSTEM_ADMIN_GROUP = "<SYSTEMADMINGROUP>"
+
+
 def get_user():
     """Get the current username from the USER environment variable."""
     return os.environ.get('USER', 'unknown')
@@ -26,6 +30,11 @@ def get_user_metaloc():
 def get_group_metaloc():
     """Get the group metadata base location."""
     return os.path.expandvars("<GROUPMETDIR>")
+
+
+def get_system_metaloc():
+    """Get the system-wide hprc_envs location."""
+    return SYSTEM_ENV_DIR
 
 
 def get_user_groups():
@@ -49,6 +58,24 @@ def load_user_metadata():
         raise Exception(f"User metadata file is corrupted or not in JSON format: {e}")
     except Exception as e:
         raise Exception(f"Unexpected error reading user metadata: {e}")
+
+
+def load_system_metadata():
+    """Load metadata from the system-wide hprc_envs directory."""
+    metadata_path = os.path.join(SYSTEM_ENV_DIR, 'metadata.json')
+    try:
+        with open(metadata_path, 'r') as file:
+            return json.load(file)
+    except FileNotFoundError:
+        return {"environments": []}
+    except json.JSONDecodeError:
+        print("Warning: System metadata file is corrupted or not in JSON format")
+        return {"environments": []}
+    except PermissionError:
+        return {"environments": []}
+    except Exception as e:
+        print(f"Warning: Unexpected error reading system metadata: {e}")
+        return {"environments": []}
 
 
 def load_group_metadata(group_name):
@@ -91,16 +118,17 @@ def load_all_metadata():
     """
     all_metadata = {
         'user': load_user_metadata(),
-        'groups': {}
+        'groups': {},
+        'system': load_system_metadata()
     }
-    
+
     # Load metadata from all user groups
     groups = get_user_groups()
     for group in groups:
         group_metadata = load_group_metadata(group)
         if group_metadata.get('environments'):  # Only include groups with environments
             all_metadata['groups'][group] = group_metadata
-    
+
     return all_metadata
 
 
@@ -128,7 +156,12 @@ def find_environment_by_name(env_name):
         for env in group_metadata.get('environments', []):
             if env.get('name') == env_name:
                 return ('group', group_name, env)
-    
+
+    # Search in system environments
+    for env in all_metadata['system'].get('environments', []):
+        if env.get('name') == env_name:
+            return ('system', 'system', env)
+
     return (None, None, None)
 
 
@@ -150,6 +183,8 @@ def get_environment_path(env_name, source_type, source_name):
     elif source_type == 'group':
         group_metaloc = get_group_metaloc()
         return os.path.join(group_metaloc, source_name, 'virtual_envs', env_name)
+    elif source_type == 'system':
+        return os.path.join(SYSTEM_ENV_DIR, env_name)
     else:
         raise ValueError(f"Invalid source_type: {source_type}")
 
@@ -171,6 +206,8 @@ def get_metadata_file_path(source_type, source_name):
     elif source_type == 'group':
         group_metaloc = get_group_metaloc()
         return os.path.join(group_metaloc, source_name, 'virtual_envs', 'metadata.json')
+    elif source_type == 'system':
+        return os.path.join(SYSTEM_ENV_DIR, 'metadata.json')
     else:
         raise ValueError(f"Invalid source_type: {source_type}")
 
@@ -208,8 +245,10 @@ def remove_environment_from_metadata(env_name):
     # Load the appropriate metadata
     if source_type == 'user':
         metadata = load_user_metadata()
-    else:  # group
+    elif source_type == 'group':
         metadata = load_group_metadata(source_name)
+    else:  # system
+        metadata = load_system_metadata()
     
     # Remove the environment
     environments = metadata.get('environments', [])


### PR DESCRIPTION
  - utils: add SYSTEM_ENV_DIR/SYSTEM_ADMIN_GROUP constants,
    load_system_metadata(), get_system_metaloc(),
    system handling in find_environment_by_name, get_environment_path,
    get_metadata_file_path, remove_environment_from_metadata
  - cli: add --system flag to create and list;
    default list shows system envs; --system hidden from help for $SYSTEM_ADMIN_GROUP users
  - when a user activates system-env readonly message pops up
  - setup.sh/Makefile: require MODULAIR_SYSTEM_ENV_DIR and
    MODULAIR_SYSTEM_ADMIN_GROUP